### PR TITLE
Rule: All includes MUST be on top of a translation unit

### DIFF
--- a/esp8266/esp_wget/esp_wget.ino
+++ b/esp8266/esp_wget/esp_wget.ino
@@ -1,20 +1,14 @@
 #include <stdint.h>
-// based on https://github.com/esp8266/Arduino/blob/master/libraries/ESP8266HTTPClient/examples/BasicHttpClient/BasicHttpClient.ino
+#include <ESP8266WiFi.h>
+#include <ESP8266WiFiMulti.h>
+#include <ESP8266HTTPClient.h>
+#include <WiFiClient.h>
+#include <Arduino.h>
+#include "wifi_settings.h"
 
 #define VERSION "0.3.0.a"
 
-#include <Arduino.h>
-
-#include <ESP8266WiFi.h>
-#include <ESP8266WiFiMulti.h>
-
-#include <ESP8266HTTPClient.h>
-
-#include <WiFiClient.h>
-
 ESP8266WiFiMulti WiFiMulti;
-
-#include "wifi_settings.h"
 
 String url;
 

--- a/main/main/main.ino
+++ b/main/main/main.ino
@@ -1,23 +1,19 @@
 #include <stdint.h>
+#include <VescUart.h>
+#include <datatypes.h>
+#include <Pixy2.h>
+#include <ArduinoUniqueID.h> // to read serial number of arduino board
+#include <EEPROM.h>
+
 #define VERSION "0.9.2.1" // report events false positive fix line_lost
 
-
-#include <ArduinoUniqueID.h> // to read serial number of arduino board
 String arduino_serial = "";
 #define AGV_NAME "AGV_DEV"
 #define WIFI_REPORTING_INTERVAL_IN_SECS 30
 
-
 // To use VescUartControl stand alone you need to define a config.h file, that should contain the Serial or you have to comment the line
 // #include Config.h out in VescUart.h
 // This lib version tested with vesc fw 3.38 and 3.40 on teensy 3.2 and arduino uno
-
-//VESC
-#include <VescUart.h>
-#include <datatypes.h>
-
-//Pixy 
-#include <Pixy2.h>
 
 //Serial ports
 #define SERIAL_RIGHT Serial1
@@ -86,7 +82,6 @@ String arduino_serial = "";
 Pixy2 pixy;
 
 //Handle km 
-#include <EEPROM.h>
 #define FORCE_EEPROM_RESET 0
 #define EE_ADDRESS 20  // a bug in previous release damaged the flash at address 0x00
 #define MM_PER_TACHO_UNIT  1.377467548  // 260 tacho per rev  / 358.11 mm circumference (114 mm diamter * pi)

--- a/rplidar_arduino/rplidar_arduino/rplidar_arduino.ino
+++ b/rplidar_arduino/rplidar_arduino/rplidar_arduino.ino
@@ -1,9 +1,7 @@
 #include <stdint.h>
+#include <RPLidar.h>
 
 #define VERSION "0.6" // send ALL_OK while booting
-
-// This sketch code is based on the RPLIDAR driver library provided by RoboPeak
-#include <RPLidar.h>
 
 // You need to create an driver instance
 RPLidar lidar;

--- a/rplidar_arduino/simple_connect/simple_connect.ino
+++ b/rplidar_arduino/simple_connect/simple_connect.ino
@@ -1,6 +1,4 @@
 #include <stdint.h>
-
-// This sketch code is based on the RPLIDAR driver library provided by RoboPeak
 #include <RPLidar.h>
 
 // You need to create an driver instance


### PR DESCRIPTION
It is best practice to keep all #include together at the top of a
translation unit or header in order to group all dependencies
together.